### PR TITLE
Fix exam schedule entries with no location

### DIFF
--- a/src/com/nasageek/utexasutilities/fragments/ExamScheduleFragment.java
+++ b/src/com/nasageek/utexasutilities/fragments/ExamScheduleFragment.java
@@ -310,9 +310,13 @@ public class ExamScheduleFragment extends SherlockFragment implements ActionMode
                 name = examdata[2];
                 date = "";
                 location = "";
-                if (examRequested && !summerSession && examdata.length >= 5) {
-                    date = examdata[3];
-                    location = examdata[4];
+                if (examRequested && !summerSession) {
+                    if (examdata.length >= 4) {
+                        date = examdata[3];
+                    }
+                    if (examdata.length >= 5) {
+                        location = examdata[4];
+                    }
                 }
             } catch (ArrayIndexOutOfBoundsException ex) {
                 ex.printStackTrace();
@@ -359,7 +363,8 @@ public class ExamScheduleFragment extends SherlockFragment implements ActionMode
                 if (elements.length >= 3) { // TODO: check this?
                     if (elements[2].contains("The department")
                             || elements[2]
-                                    .contains("Information on final exams is available for Nine-Week Summer Session(s) only.")) {
+                                    .contains("Information on final exams is available for Nine-Week Summer Session(s) only.")
+                            || elements.length <= 4) {
                         return true;
                     }
                 } else {


### PR DESCRIPTION
This fixes issue #20.

Screenshot:
![screenshot_2014-10-02-03-42-30](https://cloud.githubusercontent.com/assets/4985970/4488605/1f2b609c-4a10-11e4-86d8-a64793ba4bee.png)
